### PR TITLE
feat: added test coverage for PDF exporter

### DIFF
--- a/src/components/HarmonyPDFExport.js
+++ b/src/components/HarmonyPDFExport.js
@@ -2,113 +2,91 @@ import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 import { format } from 'date-fns';
 
-
-
-
 export class HarmonyPDFExport {
-constructor(JsPdfClass = jsPDF) {
-  this.doc = new JsPdfClass()
-}
+  constructor(JsPdfClass = jsPDF) {
+    this.doc = new JsPdfClass()
+  }
+  
+  async generateReport(data) {
+    const {
+      matches,
+      instruments,
+      threshold,
+      selectedMatches = []
+    } = data;
 
+    // Header
+    this.doc.setFontSize(24);
+    this.doc.text('Harmony Data Report', 105, 20, { align: 'center' });
+    
+    // Summary section
+    this.addSummarySection({
+      totalMatches: matches.length,
+      selectedMatches: selectedMatches.length,
+      instrumentCount: instruments.length,
+      threshold
+    });
+    
+    // Matches table
+    this.addMatchesTable(matches, selectedMatches);
+    
+    return this.doc.output('blob');
+  }
 
+  addSummarySection(summary) {
+    const summaryData = [
+      ['Generated', format(new Date(), 'PPpp')],
+      ['Total Instruments', summary.instrumentCount],
+      ['Total Matches', summary.totalMatches],
+      ['Selected Matches', summary.selectedMatches],
+      ['Match Threshold', `${summary.threshold}%`]
+    ];
 
+    this.doc.autoTable({
+      startY: 30,
+      head: [],
+      body: summaryData,
+      theme: 'plain',
+      margin: { left: 20 },
+      styles: { fontSize: 12 }
+    });
+  }
 
-async generateReport(data) {
-  const {
-    matches,
-    instruments,
-    threshold,
-    selectedMatches = []
-  } = data;
-
-
-
-
-  // Header
-  this.doc.setFontSize(24);
-  this.doc.text('Harmony Data Report', 105, 20, { align: 'center' });
-   // Summary section
-  this.addSummarySection({
-    totalMatches: matches.length,
-    selectedMatches: selectedMatches.length,
-    instrumentCount: instruments.length,
-    threshold
-  });
-
-
-
-
-  // Matches table
-  this.addMatchesTable(matches, selectedMatches);
-
-
-
-
-  return this.doc.output('blob');
-}
-
-
-
-
-addSummarySection(summary) {
-  const summaryData = [
-    ['Generated', format(new Date(), 'PPpp')],
-    ['Total Instruments', summary.instrumentCount],
-    ['Total Matches', summary.totalMatches],
-    ['Selected Matches', summary.selectedMatches],
-    ['Match Threshold', `${summary.threshold}%`]
-  ];
-
-
-
-
-  this.doc.autoTable({
-    startY: 30,
-    head: [],
-    body: summaryData,
-    theme: 'plain',
-    margin: { left: 20 },
-    styles: { fontSize: 12 }
-  });
-}
-
-
-
-
-addMatchesTable(matches, selectedMatches) {
-  const tableBody = matches.map(match => [
-    match.question1.question_text,
-    match.question1.instrument_name,
-    match.question2.question_text,
-    match.question2.instrument_name,
-    `${(match.score * 100).toFixed(1)}%`
-  ]);
-   this.doc.autoTable({
-    startY: this.doc.lastAutoTable ? this.doc.lastAutoTable.finalY + 20 : 60,
-    head: [['Question 1', 'Instrument 1', 'Question 2', 'Instrument 2', 'Score']],
-    body: tableBody,
-    theme: 'grid',
-    styles: {
-      fontSize: 9,
-      overflow: 'linebreak',
-      cellPadding: 2,
-    },
-    columnStyles: {
-      0: { cellWidth: 60 }, // Question 1
-      1: { cellWidth: 30 }, // Instrument 1
-      2: { cellWidth: 60 }, // Question 2
-      3: { cellWidth: 30 }, // Instrument 2
-      4: { cellWidth: 20 }, // Score
-    },
-    headStyles: {
-      fillColor: [33, 69, 237],
-      textColor: 255,
-      fontSize: 10
-    },
-    didDrawPage: (data) => {
-      this.doc.setFontSize(10);
-      this.doc.text(`Page ${this.doc.internal.getNumberOfPages()}`, this.doc.internal.pageSize.getWidth() - 20, this.doc.internal.pageSize.getHeight() - 10, { align: 'right' });
-    }
-  });
-}
+  addMatchesTable(matches, selectedMatches) {
+    const tableBody = matches.map(match => [
+      match.question1.question_text,
+      match.question1.instrument_name,
+      match.question2.question_text,
+      match.question2.instrument_name,
+      `${(match.score * 100).toFixed(1)}%`
+    ]);
+    
+    this.doc.autoTable({
+      startY: this.doc.lastAutoTable ? this.doc.lastAutoTable.finalY + 20 : 60,
+      head: [['Question 1', 'Instrument 1', 'Question 2', 'Instrument 2', 'Score']],
+      body: tableBody,
+      theme: 'grid',
+      styles: {
+        fontSize: 9,
+        overflow: 'linebreak',
+        cellPadding: 2,
+      },
+      columnStyles: {
+        0: { cellWidth: 60 }, // Question 1
+        1: { cellWidth: 30 }, // Instrument 1
+        2: { cellWidth: 60 }, // Question 2
+        3: { cellWidth: 30 }, // Instrument 2
+        4: { cellWidth: 20 }, // Score
+      },
+      headStyles: {
+        fillColor: [33, 69, 237],
+        textColor: 255,
+        fontSize: 10
+      },
+      didDrawPage: (data) => {
+        this.doc.setFontSize(10);
+        this.doc.text(`Page ${this.doc.internal.getNumberOfPages()}`, this.doc.internal.pageSize.getWidth() - 20, this.doc.internal.pageSize.getHeight() - 10, { align: 'right' });
+      }
+    });
+  }
 }

--- a/src/components/HarmonyPDFExport.js
+++ b/src/components/HarmonyPDFExport.js
@@ -2,91 +2,113 @@ import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 import { format } from 'date-fns';
 
+
+
+
 export class HarmonyPDFExport {
-  constructor() {
-    this.doc = new jsPDF();
-  }
+constructor(JsPdfClass = jsPDF) {
+  this.doc = new JsPdfClass()
+}
 
-  async generateReport(data) {
-    const {
-      matches,
-      instruments,
-      threshold,
-      selectedMatches = []
-    } = data;
 
-    // Header
-    this.doc.setFontSize(24);
-    this.doc.text('Harmony Data Report', 105, 20, { align: 'center' });
-    
-    // Summary section
-    this.addSummarySection({
-      totalMatches: matches.length,
-      selectedMatches: selectedMatches.length,
-      instrumentCount: instruments.length,
-      threshold
-    });
 
-    // Matches table
-    this.addMatchesTable(matches, selectedMatches);
 
-    return this.doc.output('blob');
-  }
+async generateReport(data) {
+  const {
+    matches,
+    instruments,
+    threshold,
+    selectedMatches = []
+  } = data;
 
-  addSummarySection(summary) {
-    const summaryData = [
-      ['Generated', format(new Date(), 'PPpp')],
-      ['Total Instruments', summary.instrumentCount],
-      ['Total Matches', summary.totalMatches],
-      ['Selected Matches', summary.selectedMatches],
-      ['Match Threshold', `${summary.threshold}%`]
-    ];
 
-    this.doc.autoTable({
-      startY: 30,
-      head: [],
-      body: summaryData,
-      theme: 'plain',
-      margin: { left: 20 },
-      styles: { fontSize: 12 }
-    });
-  }
 
-  addMatchesTable(matches, selectedMatches) {
-    const tableBody = matches.map(match => [
-      match.question1.question_text,
-      match.question1.instrument_name,
-      match.question2.question_text,
-      match.question2.instrument_name,
-      `${(match.score * 100).toFixed(1)}%`
-    ]);
-  
-    this.doc.autoTable({
-      startY: this.doc.lastAutoTable ? this.doc.lastAutoTable.finalY + 20 : 60,
-      head: [['Question 1', 'Instrument 1', 'Question 2', 'Instrument 2', 'Score']],
-      body: tableBody,
-      theme: 'grid',
-      styles: {
-        fontSize: 9,
-        overflow: 'linebreak',
-        cellPadding: 2,
-      },
-      columnStyles: {
-        0: { cellWidth: 60 }, // Question 1
-        1: { cellWidth: 30 }, // Instrument 1
-        2: { cellWidth: 60 }, // Question 2
-        3: { cellWidth: 30 }, // Instrument 2
-        4: { cellWidth: 20 }, // Score
-      },
-      headStyles: {
-        fillColor: [33, 69, 237],
-        textColor: 255,
-        fontSize: 10
-      },
-      didDrawPage: (data) => {
-        this.doc.setFontSize(10);
-        this.doc.text(`Page ${this.doc.internal.getNumberOfPages()}`, this.doc.internal.pageSize.getWidth() - 20, this.doc.internal.pageSize.getHeight() - 10, { align: 'right' });
-      }
-    });
-  }
+
+  // Header
+  this.doc.setFontSize(24);
+  this.doc.text('Harmony Data Report', 105, 20, { align: 'center' });
+   // Summary section
+  this.addSummarySection({
+    totalMatches: matches.length,
+    selectedMatches: selectedMatches.length,
+    instrumentCount: instruments.length,
+    threshold
+  });
+
+
+
+
+  // Matches table
+  this.addMatchesTable(matches, selectedMatches);
+
+
+
+
+  return this.doc.output('blob');
+}
+
+
+
+
+addSummarySection(summary) {
+  const summaryData = [
+    ['Generated', format(new Date(), 'PPpp')],
+    ['Total Instruments', summary.instrumentCount],
+    ['Total Matches', summary.totalMatches],
+    ['Selected Matches', summary.selectedMatches],
+    ['Match Threshold', `${summary.threshold}%`]
+  ];
+
+
+
+
+  this.doc.autoTable({
+    startY: 30,
+    head: [],
+    body: summaryData,
+    theme: 'plain',
+    margin: { left: 20 },
+    styles: { fontSize: 12 }
+  });
+}
+
+
+
+
+addMatchesTable(matches, selectedMatches) {
+  const tableBody = matches.map(match => [
+    match.question1.question_text,
+    match.question1.instrument_name,
+    match.question2.question_text,
+    match.question2.instrument_name,
+    `${(match.score * 100).toFixed(1)}%`
+  ]);
+   this.doc.autoTable({
+    startY: this.doc.lastAutoTable ? this.doc.lastAutoTable.finalY + 20 : 60,
+    head: [['Question 1', 'Instrument 1', 'Question 2', 'Instrument 2', 'Score']],
+    body: tableBody,
+    theme: 'grid',
+    styles: {
+      fontSize: 9,
+      overflow: 'linebreak',
+      cellPadding: 2,
+    },
+    columnStyles: {
+      0: { cellWidth: 60 }, // Question 1
+      1: { cellWidth: 30 }, // Instrument 1
+      2: { cellWidth: 60 }, // Question 2
+      3: { cellWidth: 30 }, // Instrument 2
+      4: { cellWidth: 20 }, // Score
+    },
+    headStyles: {
+      fillColor: [33, 69, 237],
+      textColor: 255,
+      fontSize: 10
+    },
+    didDrawPage: (data) => {
+      this.doc.setFontSize(10);
+      this.doc.text(`Page ${this.doc.internal.getNumberOfPages()}`, this.doc.internal.pageSize.getWidth() - 20, this.doc.internal.pageSize.getHeight() - 10, { align: 'right' });
+    }
+  });
+}
 }

--- a/src/components/HarmonyPDFExport.test.js
+++ b/src/components/HarmonyPDFExport.test.js
@@ -1,0 +1,119 @@
+jest.mock('jspdf', () => {
+    const fakeImpl = () => ({
+      internal: {
+        getNumberOfPages: jest.fn().mockReturnValue(3),
+        pageSize: {
+          getWidth: jest.fn().mockReturnValue(210),
+          getHeight: jest.fn().mockReturnValue(297),
+        },
+      },
+      setFontSize: jest.fn(),
+      text:        jest.fn(),
+      autoTable:   jest.fn(function (opts) { this.lastAutoTable = { finalY: 100 } }),
+      output:      jest.fn().mockReturnValue('fake-blob'),
+    });
+    return { __esModule: true, default: jest.fn().mockImplementation(fakeImpl) };
+  });
+  
+ jest.mock('jspdf-autotable', () => ({}));
+ 
+ 
+ const { HarmonyPDFExport } = require('./HarmonyPDFExport');
+ 
+ 
+ describe('HarmonyPDFExport', () => {
+    let fakeDoc, FakeJsPDF, exporter
+    beforeEach(() => {
+        fakeDoc = {
+        internal: {
+            getNumberOfPages: jest.fn().mockReturnValue(3),
+            pageSize: {
+            getWidth: jest.fn().mockReturnValue(210),
+            getHeight: jest.fn().mockReturnValue(297),
+            },
+        },
+        setFontSize: jest.fn(),
+        text:        jest.fn(),
+        autoTable:   jest.fn(function (opts) { this.lastAutoTable = { finalY: 100 } }),
+        output:      jest.fn().mockReturnValue('fake-blob'),
+        }
+        FakeJsPDF = jest.fn().mockReturnValue(fakeDoc)
+        exporter = new HarmonyPDFExport(FakeJsPDF)
+    });
+ 
+ 
+    it('generateReport: should render header, summary, matches table and return blob', async () => {
+      const sampleMatch = {
+        question1: { question_text: 'Q1 text', instrument_name: 'InstA' },
+        question2: { question_text: 'Q2 text', instrument_name: 'InstB' },
+        score: 0.756,
+      };
+      const data = {
+        matches: [sampleMatch],
+        instruments: ['InstA','InstB','InstC'],
+        threshold: 80,
+        selectedMatches: [sampleMatch],
+      };
+       const blob = await exporter.generateReport(data);
+      expect(blob).toBe('fake-blob');
+       // header
+      expect(fakeDoc.setFontSize).toHaveBeenCalledWith(24);
+      expect(fakeDoc.text).toHaveBeenCalledWith(
+        'Harmony Data Report',
+        105, 20,
+        { align: 'center' }
+      );
+       // two tables
+      expect(fakeDoc.autoTable).toHaveBeenCalledTimes(2);
+       // summary table body
+      const summaryOpts = fakeDoc.autoTable.mock.calls[0][0];
+      expect(summaryOpts.body).toEqual([
+        ['Generated',expect.any(String)],
+        ['Total Instruments', 3],
+        ['Total Matches',     1],
+        ['Selected Matches',  1],
+        ['Match Threshold', '80%'],
+      ]);
+       // matches table body
+      const matchOpts = fakeDoc.autoTable.mock.calls[1][0];
+      expect(matchOpts.body).toEqual([
+        ['Q1 text','InstA','Q2 text','InstB','75.6%']
+      ]);
+       // footer callback
+      matchOpts.didDrawPage();
+      expect(fakeDoc.setFontSize).toHaveBeenLastCalledWith(10);
+      expect(fakeDoc.text).toHaveBeenLastCalledWith(
+        'Page 3',
+        190, // 210 - 20
+        287, // 297 - 10
+        { align: 'right' }
+      );
+    });
+     it('addSummarySection: should call autoTable with exactly the summary data', () => {
+      exporter.addSummarySection({
+        instrumentCount: 5,
+        totalMatches:    2,
+        selectedMatches: 1,
+        threshold:       42,
+      });
+       expect(fakeDoc.autoTable).toHaveBeenCalledTimes(1);
+      const opts = fakeDoc.autoTable.mock.calls[0][0];
+      expect(opts.body[1]).toEqual(['Total Instruments', 5]);
+      expect(opts.body[4]).toEqual(['Match Threshold', '42%']);
+    });
+     it('addMatchesTable: should render matches correctly and attach a footer callback', () => {
+      const matches = [
+        { question1:{question_text:'foo',instrument_name:'X'}, question2:{question_text:'bar',instrument_name:'Y'}, score:0.5 },
+        { question1:{question_text:'baz',instrument_name:'Z'}, question2:{question_text:'qux',instrument_name:'W'}, score:1.0 },
+      ];
+      exporter.addMatchesTable(matches, []);
+      expect(fakeDoc.autoTable).toHaveBeenCalledTimes(1);
+       const opts = fakeDoc.autoTable.mock.calls[0][0];
+      expect(opts.body).toEqual([
+        ['foo','X','bar','Y','50.0%'],
+        ['baz','Z','qux','W','100.0%'],
+      ]);
+      expect(typeof opts.didDrawPage).toBe('function');
+    });
+ });
+ 


### PR DESCRIPTION
Modified the HarmonyPDFExporter class constructor to accept a mock jsPDF class (default value is set to the real jsPDF class), allowing for better testing. Added a file HarmonyPDFExporter.test.js which includes Jest mocks and unit tests which cover each method of the HarmonyPDFExporter class. These tests are automatically integrated into the test script, so they are run in addition to the existing tests. Because of this, no additional workflow is required.